### PR TITLE
Fixing the widening of the canvas

### DIFF
--- a/ReadEtextsActivity.py
+++ b/ReadEtextsActivity.py
@@ -200,8 +200,8 @@ class ReadEtextsActivity(activity.Activity):
         self.textview = Gtk.TextView()
         self.textview.set_editable(False)
         self.textview.set_cursor_visible(False)
-        self.textview.set_left_margin(50)
-        self.textview.set_right_margin(50)
+        self.textview.set_left_margin(5)
+        self.textview.set_right_margin(5)
         self.textview.set_wrap_mode(Gtk.WrapMode.WORD)
         self.textview.connect("key_press_event", self.keypress_cb)
 


### PR DESCRIPTION
The canvas misbehaves causing the stop button to sweep into the right.

Decreasing the margin of the text in the textview fixed the issue.

Fixes https://github.com/sugarlabs/readetexts/issues/10