### PR TITLE
Fix tube channel state

### DIFF
--- a/ReadEtextsActivity.py
+++ b/ReadEtextsActivity.py
@@ -1500,7 +1500,8 @@ class ReadEtextsActivity(activity.Activity):
         logger.debug('New tube: ID=%d initator=%d type=%d service=%s '
                       'params=%r state=%d', tube_id, initiator, tube_type,
                       service, params, state)
-        if service == READ_STREAM_SERVICE:
+        if service == READ_STREAM_SERVICE and\
+        state == telepathy.TUBE_CHANNEL_STATE_LOCAL_PENDING:
             logger.debug('I could download from that tube')
             self.unused_download_tubes.add(tube_id)
             # if no download is in progress, let's fetch the document


### PR DESCRIPTION
The download_document expects a LOCAL_PENDING tube state(value 0) but
gets a OPEN state(value 1).

Add a check to verify that the tube state is LOCAL_PENDING.

Fixes https://github.com/sugarlabs/readetexts/issues/15