### PR TITLE
Remove redundant logging

### DIFF
--- a/ReadEtextsActivity.py
+++ b/ReadEtextsActivity.py
@@ -1379,7 +1379,6 @@ class ReadEtextsActivity(activity.Activity):
         self.etext_file.seek(0)
         while self.etext_file:
             line = str(self.etext_file.readline().decode('iso-8859-1'))
-            print(line)
             line_length = len(line)
             if not line:
                 break


### PR DESCRIPTION
An extra `print(line)` was added on 33fa851f5b489862cb8b58bb4b44085f13c082a5, which was meant for debugging