### PR TITLE
Fix: Activity fails to run with ValueError

### DIFF
--- a/ReadEtextsActivity.py
+++ b/ReadEtextsActivity.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('TelepathyGLib', '0.12')
 from readtoolbar import SpeechToolbar
 import network
 import pgconvert
@@ -49,9 +52,6 @@ import re
 import logging
 import time
 import zipfile
-import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('TelepathyGLib', '0.12')
 
 
 PAGE_SIZE = 38


### PR DESCRIPTION
ValueError: NameSpace Gtk is already loaded with version 4.0

```
➜  ReadETexts git:(master) ✗ sugar-activity3 .
/home/sparsh/Code/ReadETexts/readtoolbar.py:23: PyGIWarning: Pango was imported without specifying a version first. Use gi.require_version('Pango', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import Pango
/home/sparsh/Code/ReadETexts/readtoolbar.py:25: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '4.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk
Traceback (most recent call last):
  File "/usr/bin/sugar-activity3", line 5, in <module>
    activityinstance.main()
  File "/usr/lib/python3.11/site-packages/sugar3/activity/activityinstance.py", line 179, in main
    module = __import__(module_name)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sparsh/Code/ReadETexts/ReadEtextsActivity.py", line 19, in <module>
    from readtoolbar import SpeechToolbar
  File "/home/sparsh/Code/ReadETexts/readtoolbar.py", line 28, in <module>
    from sugar3.graphics.toolbutton import ToolButton
  File "/usr/lib/python3.11/site-packages/sugar3/graphics/toolbutton.py", line 49, in <module>
    from sugar3.graphics.icon import Icon
  File "/usr/lib/python3.11/site-packages/sugar3/graphics/icon.py", line 100, in <module>
    gi.require_version('Gtk', '3.0')
  File "/usr/lib64/python3.11/site-packages/gi/__init__.py", line 117, in require_version
    raise ValueError('Namespace %s is already loaded with version %s' %
ValueError: Namespace Gtk is already loaded with version 4.0
```